### PR TITLE
chore(engine): use >= instead of ~ for engine version to avoid warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "make test"
   },
   "engines": {
-    "node": "~0.10.22"
+    "node": ">=0.10.22"
   },
   "dependencies": {
     "stluafed": "~0.0.4"


### PR DESCRIPTION
#### What?

Update the engine semver definition to avoid warning as `npm WARN engine ak-template@0.0.3: wanted: {"node":"~0.10.22"} (current: {"node":"4.2.3","npm":"2.14.7"})`

#### How?

Use `>=` instead of `~` for semver