### PR TITLE
fix(quote): escape quote with the right html value

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -67,5 +67,5 @@ template.escape = function (str) {
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt')
     .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39');
+    .replace(/'/g, '&#39;');
 };

--- a/test/index.js
+++ b/test/index.js
@@ -78,7 +78,7 @@ describe('template', function () {
       'number': 123
     });
 
-    assert.equal(html, '<div>&lt;script&gtalert(&quot;&#39&amp;&quot;)&lt;/script&gt123</div>');
+    assert.equal(html, '<div>&lt;script&gtalert(&quot;&#39;&amp;&quot;)&lt;/script&gt123</div>');
 
     done();
   });


### PR DESCRIPTION
## What?

### Currently

Simple quote `'` is escaped with `&#39`

### Expected

Simple quote `'` should be escape with `&#39;`

## How?

* Escape `'` with  `&#39;`